### PR TITLE
Fix issues when used as a jpm dependency

### DIFF
--- a/core.js
+++ b/core.js
@@ -1,7 +1,7 @@
 const { Cc, Ci } = require("chrome");
 const { OS: {File}} = require("resource://gre/modules/osfile.jsm");
 const { Task } = require("resource://gre/modules/Task.jsm");
-const { Conversion, Status } = require("dev/gcli");
+const { Conversion, Status } = require("./dev/gcli");
 const { fromFilename: toFileURI } = require("sdk/url");
 const { ZipWriter } = require("./zip");
 const { readManifest } = require("./rdf");

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jpm",
+  "name": "jpm-addon",
   "id": "@jpm",
   "version": "0.0.1",
   "description": "Jetpack Mechanic utilities for creating, testing, running and packaging Mozilla Jetpack Addons",

--- a/util.js
+++ b/util.js
@@ -1,10 +1,12 @@
 "use strict";
 
+const baseURI = module.uri.replace("/util.js", "");
+
 const writeBootstrap = (mountURI, manifest) =>
 `"use strict";
 const { utils: Cu } = Components;
-const {require} = Cu.import("resource://jpm/toolkit/require.js", {});
-const {Bootstrap} = require("resource://jpm/boot.js");
+const {require} = Cu.import("${baseURI}/toolkit/require.js", {});
+const {Bootstrap} = require("${baseURI}/boot.js");
 const {startup, shutdown, install, uninstall} = new Bootstrap("${mountURI}");
 `
 exports.writeBootstrap = writeBootstrap;


### PR DESCRIPTION
small tweaks which I've in my temporary branch to be able to use jpm-addon as an npm/jpm dependency
(loaded inside the jpm-addon-watch Firefox addon).